### PR TITLE
Set cookies as base64 encoded httonly cookies through a netlify service [Copilot Workspace generated]

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -9,6 +9,30 @@ import { ThemeManager } from "./thememanager.js";
 import { Toolbar } from "./toolbar.js";
 import { NullableString, removeFromArray } from "./utilities.js";
 
+async function postDataToService(data: any) {
+    const response = await fetch('/.netlify/functions/setCookie', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    });
+    return response.json();
+}
+
+async function getDataFromService() {
+    const response = await fetch('/.netlify/functions/setCookie', {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+    if (response.status === 200) {
+        return response.json();
+    }
+    return null;
+}
+
 function toggleEmptyState(isEmpty: boolean): void {
     document.body.classList.toggle("ui-empty-state", isEmpty);
 }
@@ -146,7 +170,7 @@ let State: {
     ManageCountdowns: ManageCountdowns;
 };
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
     /**
      * Gets a JSConfetti instance, initializing it if needed
      * @returns The instance of JSConfetti to use to play confetti
@@ -309,6 +333,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (countdownManager.getCountdownsSnapshot().length === 0) {
+        const serviceData = await getDataFromService();
+        if (serviceData) {
+            countdownManager.loadCountdownsFromService(serviceData);
+        }
         toggleEmptyState(true);
         welcomeCountdowns.show();
     }

--- a/web/src/netlify/functions/setCookie.js
+++ b/web/src/netlify/functions/setCookie.js
@@ -1,0 +1,50 @@
+const cookie = require('cookie');
+
+exports.handler = async function(event, context) {
+  if (event.httpMethod === 'POST') {
+    const data = JSON.parse(event.body);
+    const encodedData = Buffer.from(JSON.stringify(data)).toString('base64');
+    return {
+      statusCode: 200,
+      headers: {
+        'Set-Cookie': cookie.serialize('countdownData', encodedData, {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'strict',
+          path: '/',
+          maxAge: 60 * 60 * 24 * 365 // 1 year
+        }),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ message: 'Cookie set successfully' })
+    };
+  } else if (event.httpMethod === 'GET') {
+    const cookies = cookie.parse(event.headers.cookie || '');
+    if (cookies.countdownData) {
+      const decodedData = Buffer.from(cookies.countdownData, 'base64').toString('utf8');
+      return {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: decodedData
+      };
+    } else {
+      return {
+        statusCode: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ message: 'No data found' })
+      };
+    }
+  } else {
+    return {
+      statusCode: 405,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ message: 'Method not allowed' })
+    };
+  }
+};


### PR DESCRIPTION
This change used Copilot Workspace to generate an alternative fix for the safari issue by using an API & bouncing though a HTTP Only cookie #7 -- solution shape was defined by the issue itself.

The brainstorm generated in response to the default prompt of 'how do I fix this issue':
![image](https://github.com/user-attachments/assets/a3ba72e5-70ff-4953-9b43-384c959882bd)

And the 'plan' it generated:
![image](https://github.com/user-attachments/assets/c9929956-4c4b-4957-9da4-c109f204fba7)
